### PR TITLE
Typo fix Mapper{Read,Write}PPU in writeCartridgePPU

### DIFF
--- a/NES Emulator/cartridge.c
+++ b/NES Emulator/cartridge.c
@@ -50,7 +50,7 @@ void writeCartridgeCPU(struct Cartridge* cartridge, Word addr, Byte val)
 
 void writeCartridgePPU(struct Cartridge* cartridge, Word addr, Byte val)
 {
-	MapperReadPPU(cartridge->mapper, addr, val);
+	MapperWritePPU(cartridge->mapper, addr, val);
 }
 
 void getPatternTableTexture(struct Cartridge* cartridge, SDL_Texture* texture, int index)


### PR DESCRIPTION
Since 9039fa0ccfe7bc2437a0bea52d66cfd2be601329, the build is broken (on Linux?, aside from #1):

```
[ 40%] Building C object NES Emulator/CMakeFiles/nesemu.dir/cartridge.c.o
/build/NESEmulator/NES Emulator/cartridge.c: In function 'writeCartridgePPU':
/build/NESEmulator/NES Emulator/cartridge.c:53:44: error: macro "MapperReadPPU" passed 3 arguments, but takes just 2
   53 |  MapperReadPPU(cartridge->mapper, addr, val);
      |                                            ^
In file included from /build/NESEmulator/NES Emulator/cartridge.c:6:
/build/NESEmulator/NES Emulator/mapper.h:23: note: macro "MapperReadPPU" defined here
   23 | #define MapperReadPPU(mapper, addr) mapper->read_ppu(mapper->mapperStruct, addr)
      |
/build/NESEmulator/NES Emulator/cartridge.c:53:2: error: 'MapperReadPPU' undeclared (first use in this function)
   53 |  MapperReadPPU(cartridge->mapper, addr, val);
      |  ^~~~~~~~~~~~~
/build/NESEmulator/NES Emulator/cartridge.c:53:2: note: each undeclared identifier is reported only once for each function it appears in
```

Prolly a copy-pasting error.