### PR TITLE
Devendor SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,15 @@
 
 project ("NES Emulator")
 
-add_subdirectory ("vendor/SDL")
+find_package (SDL2)
+if (SDL2_FOUND)
+	message (STATUS "SDL2 found, using system-installed SDL2")
+else (SDL2_FOUND)
+	message (STATUS "SDL2 not found, using vendored static SDL2")
+	set (BUILD_SHARED_LIBS OFF)
+	add_subdirectory ("vendor/SDL")
+	set (SDL2_INCLUDE_DIRS SDL2-static)
+	set (SDL2_LIBRARIES SDL2-static SDL2main)
+endif (SDL2_FOUND)
+
 add_subdirectory ("NES Emulator")

--- a/NES Emulator/CMakeLists.txt
+++ b/NES Emulator/CMakeLists.txt
@@ -2,8 +2,8 @@
 
 add_executable (nesemu "main.c"  "cpu.h" "types.h" "bus.h" "bus.c" "cartridge.h" "cpu.c" "cartridge.c" "opcodes.c" "log.c" "ppu.h" "ppu.c" "mapper.h" "mappers/mapper000.h" "mappers/mapper000.c" "mapper.c")
 
-target_include_directories(nesemu PUBLIC SDL2-static)
-target_link_libraries(nesemu PUBLIC SDL2-static SDL2main)
+target_include_directories(nesemu PUBLIC ${SDL2_INCLUDE_DIRS})
+target_link_libraries(nesemu PUBLIC ${SDL2_LIBRARIES})
 
 if(MSVC)
 target_compile_definitions(nesemu PUBLIC _CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
First try to find system-installed SDL2. Fallback to (hopefully) checked-out submodule.
Also disabled shared library build of vendored SDL2.