### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on: [ push, pull_request ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+  # - name: Dependencies [macOS]
+  #   if: runner.os == 'macOS'
+  #   run: |
+  #     export HOMEBREW_NO_INSTALL_CLEANUP=1
+  #     brew update
+  #     brew install sdl2
+
+    - name: Dependencies [Ubuntu]
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install libsdl2-dev
+
+    - name: Configure
+      run: |
+        cmake \
+          -B ${GITHUB_WORKSPACE}/build \
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: |
+        cmake \
+          --build ${GITHUB_WORKSPACE}/build \
+          --config ${{env.BUILD_TYPE}} \
+          --parallel 2


### PR DESCRIPTION
Building on all major platforms.

- Ubuntu is GCC & links against system-installed SDL2
- macOS is Apple-LLVM & vendored SDL2. I would also try to make it link against the system-installed SDL2 but Homebrew on GHA seems broken. *sigh*
- Windows is MSVC & vendored SDL2

Builds on Ubuntu & macOS will immediately fail, see #1.